### PR TITLE
use proxy server.xml settings even without ssl enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## x.y.z (pending)
+
+* Set Tomcat `proxyName`/`proxyPort` even without SSL.
+  [[GH-11]](https://github.com/afklm/chef_jira/issues/11)
+
 ## 2.1.0
 
 * MIGRATED: renamed cookbook jira -> chef_jira

--- a/templates/default/tomcat/server.xml.erb
+++ b/templates/default/tomcat/server.xml.erb
@@ -56,13 +56,14 @@
                    maxHttpHeaderSize="8192"
                    protocol="HTTP/1.1"
                    useBodyEncodingForURI="true"
+                   proxyName="<%= node['jira']['apache2']['virtual_host_alias'] %>"
                    <% if node['jira']['ssl'] == true -%>
                    secure="true"
                    scheme="https"
-                   proxyName="<%= node['jira']['apache2']['virtual_host_alias'] %>"
                    proxyPort="<%= node['jira']['apache2']['ssl']['port'] %>"
                    redirectPort="<%= node['jira']['apache2']['ssl']['port'] %>"
                    <% else -%>
+                   proxyPort="<%= node['jira']['apache2']['port'] %>"
                    redirectPort="<%= node['jira']['tomcat']['ssl_port'] %>"
                    <% end -%>
                    acceptCount="100"


### PR DESCRIPTION
The setup wizard seems to take the base url from the proxy settings, and defaults to localhost without. This seems to solve that. (PR forthcoming)