### PR TITLE
Update old database-type string for postgres 9.2 & 9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## x.y.z (pending)
+
+* Added support for PostgreSQL 9.2+ in `dbconfig.xml`.
+  [[GH-14]](https://github.com/afklm/chef_jira/issues/14)
+
 ## 2.1.0
 
 * MIGRATED: renamed cookbook jira -> chef_jira

--- a/templates/default/dbconfig.xml.erb
+++ b/templates/default/dbconfig.xml.erb
@@ -7,7 +7,7 @@
   <% when "mysql" -%>
   <database-type>mysql</database-type>
   <% when "postgresql" -%>
-  <database-type>postgres</database-type>
+  <database-type>postgres72</database-type>
   <schema-name>public</schema-name>
   <% when "mssql" -%>
   <database-type>mssql</database-type>


### PR DESCRIPTION
https://github.com/afklm/chef_jira/blob/f40871326283f1dde233b1e3f1a009c8173ba022/templates/default/dbconfig.xml.erb#L10

In the line above, the database-type is set to postgres. It seems that since at least postgres 9.2, postgres72 should be used. I've confirmed this bug and fix for Jira v6.4.11 with postgresql v9.3.9, and the docs say it should be the same for psql 9.2

We could make it dynamic based on postgres version, but I think we should fix it now, and fix it for older versions if we add convergence tests for them :)

Reference: https://github.com/afklm/chef_jira/blob/master/templates/default/dbconfig.xml.erb#L10