### PR TITLE
Configure home_path in `jira-application.properties` for all install types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   [[GH-11]](https://github.com/afklm/chef_jira/issues/11)
 * Removed unnecessary non-dynamic `web.xml` template.
   [[GH-10]](https://github.com/afklm/chef_jira/issues/10)
+* Fixed setting of `jira.home` for all install types.
+  [[GH-15]](https://github.com/afklm/chef_jira/issues/15)
 
 Thanks go to @elijah @gsreynolds @legal90 and @patcon for helping out in this
 release.

--- a/recipes/configuration.rb
+++ b/recipes/configuration.rb
@@ -43,3 +43,10 @@ service 'jira' do
   action :enable
   subscribes :restart, 'java_ark[jdk]'
 end
+
+template "#{node['jira']['install_path']}/atlassian-jira/WEB-INF/classes/jira-application.properties" do
+  source 'jira-application.properties.erb'
+  owner node['jira']['user']
+  mode '0644'
+  notifies :restart, 'service[jira]', :delayed
+end


### PR DESCRIPTION
Seems that we're only dropping this file in for war install type. This will be asymptomatic so long as the home_path is the default `/opt/atlassian/jira`, but break otherwise. I've only confirmed that it needs fixing for standalone install type, but the confluence cookbook makes me think it also applies to installer method:
https://github.com/bflad/chef-confluence/blob/master/recipes/configuration.rb

Incoming PR