### PR TITLE
Restart jira service when ark is re-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## x.y.z (pending)
+
+* Added service restart when ark resource changes.
+  [[GH-16]](https://github.com/afklm/chef_jira/issues/16)
+
 ## 2.1.0
 
 * MIGRATED: renamed cookbook jira -> chef_jira

--- a/recipes/standalone.rb
+++ b/recipes/standalone.rb
@@ -47,4 +47,5 @@ ark 'jira' do
   version node['jira']['version']
   owner node['jira']['user']
   group node['jira']['user']
+  notifies :restart, 'service[jira]'
 end


### PR DESCRIPTION
Right now, it seems the the jira service doesn't restart when the install_path changes or a new version is installed. This isn't common behaviour for a production instance, but particularly during testing, it would be more expected if it did