### PR TITLE
Add Jira 7 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## x.y.z (pending)
+
+* Added minimal Jira 7 compatibility via `server.xml` template.
+  [[GH-12]](https://github.com/afklm/chef_jira/issues/12)
+
 ## 2.1.0
 
 * MIGRATED: renamed cookbook jira -> chef_jira

--- a/templates/default/tomcat/server.xml.erb
+++ b/templates/default/tomcat/server.xml.erb
@@ -31,8 +31,18 @@
 
     <!--APR library loader. Documentation at /docs/apr.html -->
     <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on"/>
+    <% if node['jira']['version'].split('.')[0].to_i < 7 -%>
     <!--Initialize Jasper prior to webapps are loaded. Documentation at /docs/jasper-howto.html -->
     <Listener className="org.apache.catalina.core.JasperListener"/>
+    <% else -%>
+    <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+    <!-- Security listener. Documentation at /docs/config/listeners.html
+    <Listener className="org.apache.catalina.security.SecurityListener" />
+    -->
+    <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+    <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+    <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+    <% end -%>
     <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener"/>
 
     <!-- Global JNDI resources


### PR DESCRIPTION
At the very least, the download url format seems to be different. Not sure whether we want to force jdk 8 as well, but that's an option