### PR TITLE
Disable https on the Tomcat side

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,15 +98,9 @@ support_args | additional JAVA_OPTS recommended by Atlassian support for JIRA JV
 
 These attributes are under the `node['jira']['tomcat']` namespace.
 
-Any `node['jira']['tomcat']['key*']` attributes are overridden by `jira/jira` encrypted data bag (Hosted Chef) or data bag (Chef Solo), if it exists
-
 Attribute | Description | Type | Default
 ----------|-------------|------|--------
-keyAlias | Tomcat SSL keystore alias | String | tomcat
-keystoreFile | Tomcat SSL keystore file - will automatically generate self-signed keystore file if left as default | String | `#{node['jira']['home_path']}/.keystore`
-keystorePass | Tomcat SSL keystore passphrase | String | changeit
 port | Tomcat HTTP port | Fixnum | 8080
-ssl_port | Tomcat HTTPS port | Fixnum | 8443
 
 ## Recipes
 
@@ -133,10 +127,6 @@ _required:_
 
 _optional:_
 * `['database']['port']` - Database port, defaults to standard database port for `['database']['type']`
-* `['tomcat']['keyAlias']` - Tomcat HTTPS Java Keystore keyAlias, defaults to self-signed certifcate
-* `['tomcat']['keystoreFile']` - Tomcat HTTPS Java Keystore keystoreFile,
-  defaults to self-signed certificate
-* `['tomcat']['keystorePass']` - Tomcat HTTPS Java Keystore keystorePass, defaults to self-signed certificate
 
 Repeat for other Chef environments as necessary. Example:
 
@@ -149,11 +139,6 @@ Repeat for other Chef environments as necessary. Example:
           "name": "jira",
           "user": "jira",
           "password": "jira_db_password",
-        },
-        "tomcat": {
-          "keyAlias": "not_tomcat",
-          "keystoreFile": "/etc/pki/java/wildcard_cert.jks",
-          "keystorePass": "not_changeit"
         }
       }
     }

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -94,9 +94,7 @@ Vagrant.configure('2') do |config|
         'server_debian_password' => 'iloverandompasswordsbutthiswilldo'
       },
       'tomcat' => {
-        'java_options' => '-XX:MaxPermSize=256M -Xmx768M -Djava.awt.headless=true',
-        'keystore_password' => 'iloverandompasswordsbutthiswilldo',
-        'truststore_password' => 'iloverandompasswordsbutthiswilldo'
+        'java_options' => '-XX:MaxPermSize=256M -Xmx768M -Djava.awt.headless=true'
       }
     }
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,11 +47,7 @@ default['jira']['jvm']['maximum_permgen'] = '256m'
 default['jira']['jvm']['java_opts']       = ''
 default['jira']['jvm']['support_args']    = ''
 
-default['jira']['tomcat']['keyAlias']     = 'tomcat'
-default['jira']['tomcat']['keystoreFile'] = "#{node['jira']['home_path']}/.keystore"
-default['jira']['tomcat']['keystorePass'] = 'changeit'
-default['jira']['tomcat']['port']     = '8080'
-default['jira']['tomcat']['ssl_port'] = '8443'
+default['jira']['tomcat']['port'] = '8080'
 
 default['jira']['crowd_sso']['enabled']        = false
 default['jira']['crowd_sso']['sso_appname']    = 'jira'

--- a/recipes/installer.rb
+++ b/recipes/installer.rb
@@ -18,17 +18,3 @@ execute "Installing Jira #{node['jira']['version']}" do
   command "./atlassian-jira-#{node['jira']['version']}-#{node['jira']['arch']}.bin -q -varfile atlassian-jira-response.varfile"
   not_if { node['jira']['update'] == false && ::File.directory?("#{node['jira']['install_path']}") }
 end
-
-execute 'Generating Self-Signed Java Keystore' do
-  command <<-COMMAND
-    #{node['jira']['install_path']}/jre/bin/keytool -genkey \
-      -alias tomcat \
-      -keyalg RSA \
-      -dname 'CN=#{node['fqdn']}, OU=Example, O=Example, L=Example, ST=Example, C=US' \
-      -keypass changeit \
-      -storepass changeit \
-      -keystore #{node['jira']['home_path']}/.keystore
-    chown #{node['jira']['user']}:#{node['jira']['user']} #{node['jira']['home_path']}/.keystore
-  COMMAND
-  creates "#{node['jira']['home_path']}/.keystore"
-end

--- a/recipes/standalone.rb
+++ b/recipes/standalone.rb
@@ -1,6 +1,5 @@
 ark_prefix_path = ::File.dirname(node['jira']['install_path']) if ::File.basename(node['jira']['install_path']) == 'jira'
 ark_prefix_path ||= node['jira']['install_path']
-settings = Jira.settings(node)
 
 directory File.dirname(node['jira']['home_path']) do
   owner 'root'
@@ -17,21 +16,6 @@ user node['jira']['user'] do
   supports :manage_home => true
   system true
   action :create
-end
-
-execute 'Generating Self-Signed Java Keystore' do
-  command <<-COMMAND
-    #{node['java']['java_home']}/bin/keytool -genkey \
-      -alias #{settings['tomcat']['keyAlias']} \
-      -keyalg RSA \
-      -dname 'CN=#{node['fqdn']}, OU=Example, O=Example, L=Example, ST=Example, C=US' \
-      -keypass #{settings['tomcat']['keystorePass']} \
-      -storepass #{settings['tomcat']['keystorePass']} \
-      -keystore #{settings['tomcat']['keystoreFile']}
-    chown #{node['jira']['user']}:#{node['jira']['user']} #{settings['tomcat']['keystoreFile']}
-  COMMAND
-  creates settings['tomcat']['keystoreFile']
-  only_if { settings['tomcat']['keystoreFile'] == "#{node['jira']['home_path']}/.keystore" }
 end
 
 directory ark_prefix_path do

--- a/templates/default/tomcat/server.xml.erb
+++ b/templates/default/tomcat/server.xml.erb
@@ -57,15 +57,10 @@
                    protocol="HTTP/1.1"
                    useBodyEncodingForURI="true"
                    proxyName="<%= node['jira']['apache2']['virtual_host_name'] %>"
-                   <% if node['jira']['ssl'] == true -%>
                    secure="true"
                    scheme="https"
                    proxyPort="<%= node['jira']['apache2']['ssl']['port'] %>"
                    redirectPort="<%= node['jira']['apache2']['ssl']['port'] %>"
-                   <% else -%>
-                   proxyPort="<%= node['jira']['apache2']['port'] %>"
-                   redirectPort="<%= node['jira']['tomcat']['ssl_port'] %>"
-                   <% end -%>
                    acceptCount="100"
                    disableUploadTimeout="true"/>
 
@@ -93,28 +88,14 @@
 
         ====================================================================================
         -->
-
-            <Connector port="<%= node['jira']['tomcat']['ssl_port'] %>"
-              protocol="org.apache.coyote.http11.Http11Protocol"
-              maxHttpHeaderSize="8192"
-              SSLEnabled="true"
-              maxThreads="150"
-              minSpareThreads="25"
-              enableLookups="false"
-              disableUploadTimeout="true"
-              acceptCount="100"
-              scheme="https"
-              secure="true"
-              clientAuth="false"
-              sslProtocol="TLS"
-              useBodyEncodingForURI="true"
-              <% if @tomcat -%>
-              <%= "keyAlias=\"#{@tomcat['keyAlias']}\"" if @tomcat['keyAlias'] %>
-              <%= "keystoreFile=\"#{@tomcat['keystoreFile']}\"" if @tomcat['keystoreFile'] %>
-              <%= "keystorePass=\"#{@tomcat['keystorePass']}\"" if @tomcat['keystorePass'] %>
-              <% end -%>
-              />
-
+        <!--
+            <Connector port="8443" protocol="org.apache.coyote.http11.Http11Protocol"
+              maxHttpHeaderSize="8192" SSLEnabled="true"
+              maxThreads="150" minSpareThreads="25"
+              enableLookups="false" disableUploadTimeout="true"
+              acceptCount="100" scheme="https" secure="true"
+              clientAuth="false" sslProtocol="TLS" useBodyEncodingForURI="true"/>
+        -->
 
 
         <!--


### PR DESCRIPTION
Most of JIRA production instances use some web server as a reverse proxy at the front of Tomcat.
In this cookbook we also configure Apache web server for these needs.

So, since https is actually terminating on the Apache side, there are no needs to manage keystore
and configure TLS/SSL on the Tomcat side.