### PR TITLE
Force to use bundled JRE for "installer" type

### DIFF
--- a/templates/default/tomcat/permgen.sh.erb
+++ b/templates/default/tomcat/permgen.sh.erb
@@ -9,11 +9,12 @@
 #
 
 # DO NOT remove the following line
-<% if node['java'] && node['java']['java_home'] -%>
-JAVA_HOME="<%= node['java']['java_home'] %>/jre/"; export JAVA_HOME
+<% if node['jira']['install_type'] == 'installer' -%>
+JAVA_HOME="<%= node['jira']['install_path'] %>/jre/"
 <% else -%>
-JAVA_HOME="<%= node['jira']['install_path'] %>/jre/"; export JAVA_HOME
+JAVA_HOME="<%= node['java']['java_home'] %>/jre/"
 <% end -%>
+export JAVA_HOME
 
 # let Tomcat's setclasspath.sh figure out the java location for us
 if $os400; then


### PR DESCRIPTION
JRE is bundled to the Jira installer and Atlassian recommends to use it for running Jira.
So, we don't need to manage Java separately if "installer" type is chosen.

While defining JAVA_HOME, I suppose to check the `['jira']['installer_type']` value instead of `['java']['java_home']`. It helps to avoid unexpected behavior if node has already some ['java'] attributes assigned.